### PR TITLE
Allow external styles and fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
     
     <!-- D3.js for layout calculations -->
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="https://d3js.org/d3.v7.min.js" defer></script>
+
+    <!-- Three.js for optional 3D features -->
+    <script src="https://unpkg.com/three@0.158.0/build/three.min.js" defer></script>
+    <script src="https://unpkg.com/three@0.158.0/examples/js/controls/OrbitControls.js" defer></script>
     
     <!-- Custom Styles -->
     <link rel="stylesheet" href="styles/main.css">

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdnjs.cloudflare.com https://d3js.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https:;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://d3js.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https:;"
 
 [[headers]]
   for = "*.js"


### PR DESCRIPTION
## Summary
- Permit stylesheets from Unpkg and data URLs for fonts in Netlify CSP
- Load Three.js and OrbitControls for optional 3D features
- Defer external libraries and tighten CSP by removing unsafe-eval and unused CDN

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68967ccbd7848328a7d461df6ebd7fc1