### PR TITLE
Add server startup test and npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "familytree",
+  "version": "1.0.0",
+  "description": "Family Tree Application",
+  "scripts": {
+    "test": "pytest"
+  }
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+def test_server_starts_and_serves_index():
+    repo_dir = Path(__file__).resolve().parent.parent
+    port = 8765
+    process = subprocess.Popen(
+        [sys.executable, "server.py", "--port", str(port)],
+        cwd=repo_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        url = f"http://localhost:{port}"
+        # wait for server to start
+        for _ in range(50):
+            try:
+                with urllib.request.urlopen(url, timeout=0.1) as response:
+                    assert response.status == 200
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            raise AssertionError("Server did not start in time")
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)


### PR DESCRIPTION
## Summary
- add pytest-based test verifying server launches and serves index
- provide package.json with npm `test` script to run pytest

## Testing
- `pytest`
- `npm test`
- `python server.py --port 8002 & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_689753fb8fb88328b46e2c270146c12d