### PR TITLE
Handle missing ELK plugin by falling back to breadthfirst layout and add logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,7 @@
     <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js" defer></script>
 
     <!-- Application Scripts -->
+    <script src="js/logger.js" defer></script>
     <script src="js/data-converter.js" defer></script>
     <script src="js/fuzzy-search.js" defer></script>
     <script src="js/family-tree-gl.js" defer></script>

--- a/js/family-tree-gl.js
+++ b/js/family-tree-gl.js
@@ -1,13 +1,3 @@
-// Register Cytoscape extensions if they are available
-if (typeof window !== 'undefined' && window.cytoscape) {
-  if (window.cytoscapeElk) {
-    window.cytoscape.use(window.cytoscapeElk);
-  }
-  if (window.cytoscapeMinimap) {
-    window.cytoscape.use(window.cytoscapeMinimap);
-  }
-}
-
 class FamilyTreeGL {
   constructor(containerId, data) {
     this.container = document.getElementById(containerId);
@@ -23,9 +13,27 @@ class FamilyTreeGL {
     const cached = localStorage.getItem('ft_positions');
     this.cachedPositions = cached ? JSON.parse(cached) : null;
 
-    const elkAvailable = !!window.cytoscapeElk;
+    // Ensure Cytoscape extensions are registered before creating the instance
+    let elkAvailable = false;
+    if (typeof window !== 'undefined' && window.cytoscape) {
+      if (window.cytoscapeElk) {
+        try {
+          window.cytoscape.use(window.cytoscapeElk);
+          elkAvailable = true;
+        } catch (e) {
+          console.error('Failed to register ELK layout plugin:', e);
+        }
+      }
+      if (window.cytoscapeMinimap) {
+        try {
+          window.cytoscape.use(window.cytoscapeMinimap);
+        } catch (e) {
+          console.error('Failed to register minimap plugin:', e);
+        }
+      }
+    }
     if (!elkAvailable) {
-      console.error('ELK layout plugin missing; falling back to breadthfirst layout');
+      console.warn('ELK layout plugin missing; falling back to breadthfirst layout');
     }
     const layoutOpts = this.cachedPositions
       ? { name: 'preset' }

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,48 @@
+(function() {
+  const stored = localStorage.getItem('ft_logs');
+  const logs = stored ? JSON.parse(stored) : [];
+
+  function persist() {
+    try {
+      localStorage.setItem('ft_logs', JSON.stringify(logs.slice(-1000)));
+    } catch (_) {
+      /* ignore storage errors */
+    }
+  }
+
+  function format(level, args) {
+    return `[${new Date().toISOString()}] ${level.toUpperCase()}: ${args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ')}`;
+  }
+
+  ['log', 'info', 'warn', 'error'].forEach(level => {
+    const original = console[level];
+    console[level] = (...args) => {
+      logs.push(format(level, args));
+      if (typeof original === 'function') {
+        original.apply(console, args);
+      }
+      persist();
+    };
+  });
+
+  window.FTLogger = {
+    getLogs() {
+      return logs.slice();
+    },
+    download() {
+      const blob = new Blob([logs.join('\n')], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'familytree.log';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+    clear() {
+      logs.length = 0;
+      persist();
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- Ensure Cytoscape extensions are registered when constructing the tree
- Fall back to the built-in breadthfirst layout if the ELK plugin can't be loaded
- Capture console messages in localStorage and expose a downloadable log file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897715bed8c83289beef52b1b466578