### PR TITLE
Switch to Dagre layout for family tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
     
-    <!-- Cytoscape.js with ELK layout and minimap -->
+    <!-- Cytoscape.js with Dagre layout and minimap -->
     <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js" defer></script>
-    <script src="https://unpkg.com/elkjs/lib/elk.bundled.js" defer></script>
-    <script src="https://unpkg.com/cytoscape-elk@2.1.0/cytoscape-elk.js" defer></script>
+    <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js" defer></script>
+    <script src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js" defer></script>
     <script src="https://unpkg.com/cytoscape-minimap@2.5.2/cytoscape-minimap.js" defer></script>
     <script src="https://unpkg.com/fuse.js@6.6.2/dist/fuse.min.js" defer></script>
     

--- a/js/family-tree-gl.js
+++ b/js/family-tree-gl.js
@@ -14,14 +14,14 @@ class FamilyTreeGL {
     this.cachedPositions = cached ? JSON.parse(cached) : null;
 
     // Ensure Cytoscape extensions are registered before creating the instance
-    let elkAvailable = false;
+    let dagreAvailable = false;
     if (typeof window !== 'undefined' && window.cytoscape) {
-      if (window.cytoscapeElk) {
+      if (window.cytoscapeDagre) {
         try {
-          window.cytoscape.use(window.cytoscapeElk);
-          elkAvailable = true;
+          window.cytoscape.use(window.cytoscapeDagre);
+          dagreAvailable = true;
         } catch (e) {
-          console.error('Failed to register ELK layout plugin:', e);
+          console.error('Failed to register Dagre layout plugin:', e);
         }
       }
       if (window.cytoscapeMinimap) {
@@ -32,13 +32,13 @@ class FamilyTreeGL {
         }
       }
     }
-    if (!elkAvailable) {
-      console.warn('ELK layout plugin missing; falling back to breadthfirst layout');
+    if (!dagreAvailable) {
+      console.warn('Dagre layout plugin missing; falling back to breadthfirst layout');
     }
     const layoutOpts = this.cachedPositions
       ? { name: 'preset' }
-      : elkAvailable
-        ? { name: 'elk', animate: false, fit: true, worker: true }
+      : dagreAvailable
+        ? { name: 'dagre', animate: false, fit: true }
         : { name: 'breadthfirst', animate: false, fit: true };
 
     this.cy = cytoscape({


### PR DESCRIPTION
## Summary
- Replace ELK layout usage with Dagre layout to prevent missing plugin errors
- Update scripts to load dagre and register the layout plugin with Cytoscape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897762a90a88328bb94f6920a6c739a